### PR TITLE
Fix packaged app blank screen

### DIFF
--- a/src/store/presentation.ts
+++ b/src/store/presentation.ts
@@ -71,6 +71,8 @@ function updateCurrentSlide(
   };
 }
 
+const UNDO_DEBOUNCE_MS = 200;
+
 /** Build a fresh presentation with global-pref seeding applied.
  *  Used both by the Zustand store's cold-start initial state AND by
  *  fileOps.createProject (Cmd+N) — they MUST stay in sync, so the
@@ -542,8 +544,6 @@ export const usePresentationStore = create<PresentationState>()(
     }
   )
 );
-
-const UNDO_DEBOUNCE_MS = 200;
 
 /** Leading-edge debounce: first call fires immediately, subsequent
  *  calls within `ms` are dropped, then the gate resets after `ms`

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ const host = process.env.TAURI_DEV_HOST;
 // https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [react()],
+  base: "./",
 
   build: {
     rollupOptions: {


### PR DESCRIPTION
This fixes the blank screen by avoiding a startup ReferenceError from reading UNDO_DEBOUNCE_MS before initialization during Zustand/zundo store creation.

Changes:
1. Configure Vite with `base: "./"` so packaged assets resolve relative to the bundled HTML. 2. Move `UNDO_DEBOUNCE_MS` above the Zustand/zundo store initialization so zundo does not read it before initialization.

Verified on macOS v26.3.1 with:
`npm run build` and `npm run tauri build`.